### PR TITLE
Avoid push when clear

### DIFF
--- a/__tests__/queue.spec.ts
+++ b/__tests__/queue.spec.ts
@@ -10,7 +10,7 @@ import type {
   setRetryHeaderPath,
   setRetryQueueConfig,
 } from '../src/';
-import type { RetryEntry } from '../src/queue';
+import type { peekQueue, RetryEntry } from '../src/queue';
 
 declare global {
   interface Window {
@@ -18,6 +18,7 @@ declare global {
     clearQueue: typeof clearQueue;
     setRetryHeaderPath: typeof setRetryHeaderPath;
     setRetryQueueConfig: typeof setRetryQueueConfig;
+    peekQueue: typeof peekQueue;
   }
 }
 
@@ -452,6 +453,7 @@ describe.each([
       },
       [server.url, createBody(contentLength)]
     );
+    await page.waitForTimeout(1000);
     const storage = await page.evaluate<RetryEntry[]>(`window.peekQueue(1)`);
     expect(storage.length).toBe(1);
 
@@ -469,6 +471,7 @@ describe.each([
       },
       [server.url, createBody(contentLength)]
     );
+    await page.waitForTimeout(1000);
 
     const storageAfterClear = await page.evaluate<RetryEntry[]>(
       `window.peekQueue(1)`

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "eslint-plugin-jest": "^24.3.6",
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "express": "^4.17.1",
-        "idb-queue": "^0.1.2",
+        "idb-queue": "^0.1.5",
         "jest": "^26.6.3",
         "npm-run-all": "^4.1.5",
         "playwright": "^1.10.0",
@@ -4944,9 +4944,9 @@
       }
     },
     "node_modules/idb-queue": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/idb-queue/-/idb-queue-0.1.2.tgz",
-      "integrity": "sha512-IOhcNWCTm65l+r6imkfKAzKskVbI+gg8Tqz3plZyvRZZZ707FLcsfT24/bO3o1CYbzZTzXbokEMC4OsOFV6S1Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/idb-queue/-/idb-queue-0.1.5.tgz",
+      "integrity": "sha512-jJ/AOVxUS0/in1FD5W4k687pqIqHF6SHHS+ylW/RxUgezTxrY6EIpYdJSt6V3T8MNu2GGYBRDs7A1y0tz+0Csw==",
       "dev": true
     },
     "node_modules/ignore": {
@@ -14868,9 +14868,9 @@
       }
     },
     "idb-queue": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/idb-queue/-/idb-queue-0.1.2.tgz",
-      "integrity": "sha512-IOhcNWCTm65l+r6imkfKAzKskVbI+gg8Tqz3plZyvRZZZ707FLcsfT24/bO3o1CYbzZTzXbokEMC4OsOFV6S1Q==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/idb-queue/-/idb-queue-0.1.5.tgz",
+      "integrity": "sha512-jJ/AOVxUS0/in1FD5W4k687pqIqHF6SHHS+ylW/RxUgezTxrY6EIpYdJSt6V3T8MNu2GGYBRDs7A1y0tz+0Csw==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-jest": "^24.3.6",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "express": "^4.17.1",
-    "idb-queue": "^0.1.2",
+    "idb-queue": "^0.1.5",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "playwright": "^1.10.0",

--- a/src/fetch-fn.ts
+++ b/src/fetch-fn.ts
@@ -1,4 +1,4 @@
-import { createRequestInit, debug } from './utils';
+import { createRequestInit } from './utils';
 
 export const supportFetch = typeof globalThis !== 'undefined' && 'fetch' in globalThis;
 
@@ -17,7 +17,6 @@ function keepaliveFetch(
     fetch(url, createRequestInit({ body, keepalive: true, headers }))
       .catch(() => {
         // keepalive true fetch can throw error if body exceeds 64kb
-        debug('fetch failed 1st');
         return fetch(
           url,
           createRequestInit({ body, keepalive: false, headers })
@@ -52,7 +51,6 @@ function fallbackFetch(
       // if the user agent is not able to successfully queue the data for transfer,
       // send the payload with fetch api instead
       if (result) {
-        debug(`sendBeacon passed, body length: ${body.length}`);
         resolve(null);
         return;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,5 +36,7 @@ export function debug(...data: any[]): void {
 }
 
 export function logError(...data: any[]): void {
-  console.error('[beacon-transporter] ', ...data);
+  if (typeof window !== 'undefined' && window.__DEBUG_BEACON_TRANSPORTER) {
+    console.error('[beacon-transporter] ', ...data);
+  }
 }


### PR DESCRIPTION
If clear happens at any time of the beacon (fetch, push when fail), mark
the beacon as is clear pending, and determine as not to persist.
idb-queue pushIfNotClearing supports the scenario when clear happens
before push. IDB spec supports clear tx starts after push tx.