### PR TITLE
Reset throttle timer when pushed to DB

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,13 +40,13 @@ export function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-export function debug(...data: any[]): void {
+export function debug(...data: string[]): void {
   if (typeof window !== 'undefined' && window.__DEBUG_BEACON_TRANSPORTER) {
     console.debug('[beacon-transporter] ', ...data);
   }
 }
 
-export function logError(...data: any[]): void {
+export function logError(...data: string[]): void {
   if (typeof window !== 'undefined' && window.__DEBUG_BEACON_TRANSPORTER) {
     console.error('[beacon-transporter] ', ...data);
   }


### PR DESCRIPTION
When a request that needs retry is pushed to DB, the throttle timer
should reset and allow next trigger to fire retry.