### PR TITLE
Do not retry again if retrying from IDB failed from response codes not in allowed status codes

### DIFF
--- a/docs/beacon-transporter.retrydb.md
+++ b/docs/beacon-transporter.retrydb.md
@@ -28,7 +28,7 @@ export declare class RetryDB
 |  Method | Modifiers | Description |
 |  --- | --- | --- |
 |  [clearQueue()](./beacon-transporter.retrydb.clearqueue.md) |  |  |
-|  [notifyQueue()](./beacon-transporter.retrydb.notifyqueue.md) |  |  |
+|  [notifyQueue(config)](./beacon-transporter.retrydb.notifyqueue.md) |  |  |
 |  [onClear(cb)](./beacon-transporter.retrydb.onclear.md) |  |  |
 |  [peekBackQueue(count)](./beacon-transporter.retrydb.peekbackqueue.md) |  |  |
 |  [peekQueue(count)](./beacon-transporter.retrydb.peekqueue.md) |  |  |

--- a/docs/beacon-transporter.retrydb.notifyqueue.md
+++ b/docs/beacon-transporter.retrydb.notifyqueue.md
@@ -7,8 +7,15 @@
 <b>Signature:</b>
 
 ```typescript
-notifyQueue(): void;
+notifyQueue(config: QueueNotificationConfig): void;
 ```
+
+## Parameters
+
+|  Parameter | Type | Description |
+|  --- | --- | --- |
+|  config | QueueNotificationConfig |  |
+
 <b>Returns:</b>
 
 void

--- a/etc/beacon-transporter.api.md
+++ b/etc/beacon-transporter.api.md
@@ -71,8 +71,10 @@ export class RetryDB {
     clearQueue(): Promise<void>;
     // (undocumented)
     static hasSupport: boolean;
+    // Warning: (ae-forgotten-export) The symbol "QueueNotificationConfig" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
-    notifyQueue(): void;
+    notifyQueue(config: QueueNotificationConfig): void;
     // (undocumented)
     onClear(cb: () => void): void;
     // (undocumented)


### PR DESCRIPTION
Currently if a req failed by network issue, and it will causing 400, the transporter will still persist back to DB and retry later. This PR fixes this.

Need to rebase onto https://github.com/xg-wang/beacon-transporter/pull/51