### PR TITLE
persisting to indexedDB for 4xx & 5xx to reduce data loss

### DIFF
--- a/src/beacon.ts
+++ b/src/beacon.ts
@@ -153,7 +153,7 @@ class Beacon<RetryDBType extends IRetryDBBase> {
     }
     const fromStatusCode =
       error.type === 'response' &&
-      this.persistenceConfig.statusCodes.includes(error.statusCode);
+      error.statusCode > 400;
     if (fromStatusCode) {
       return true;
     }


### PR DESCRIPTION
### Context

Recently we are working on calculating data loss based on the sequence number approach and the read-out came out that we have more data loss than expected. After testing in local with mock API response, turns out that 504 & 502 in memory retry won't be persisted in indexedDB after the retry attempt expires. And after aligning with mobile implementation, we want to update the logic to persist all 4xx & 5xx errors except 400.
